### PR TITLE
docs: rewrite org profile README with mission, projects, and badges

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,90 @@
-# Welcome to SSEC's GitHub Organization
+# UW Scientific Software Engineering Center (SSEC)
 
-The Scientific Software Engineering Center (SSEC) at the University of Washington works with researchers across various disciplines to build robust software that bolsters inquiry and builds community. The resulting tools are open source and reusable, designed to sustain discovery beyond SSEC’s involvement in the projects.
+**Building open, reusable, and sustainable scientific software — with researchers, for discovery.**
 
-See all of our projects at: https://escience.washington.edu/software-engineering/ssec/ssec-project-archives/
+[![Website](https://img.shields.io/badge/Website-escience.washington.edu-4B2E83?style=flat-square&logo=googlechrome&logoColor=white)](https://escience.washington.edu/software-engineering/ssec/)
+[![UW eScience Institute](https://img.shields.io/badge/UW-eScience%20Institute-4B2E83?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTEyIDNMMSA5bDExIDYgOS00Ljl2Ni45aDJWOUwxMiAzem0wIDhMMyAxMGw5IDUgOS01LTkgMXoiLz48L3N2Zz4=)](https://escience.washington.edu/)
+[![Funded by Schmidt Sciences](https://img.shields.io/badge/Funded%20by-Schmidt%20Sciences-53B2B5?style=flat-square)](https://www.schmidtsciences.org/)
+[![Open Source](https://img.shields.io/badge/Open%20Source-Always-success?style=flat-square&logo=opensourceinitiative&logoColor=white)](https://opensource.org/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square&logo=github&logoColor=white)](https://github.com/uw-ssec/.github/blob/main/CONTRIBUTING.md)
+[![Code of Conduct](https://img.shields.io/badge/Code%20of%20Conduct-Contributor%20Covenant-5E2A84?style=flat-square)](https://github.com/uw-ssec/.github/blob/main/CODE_OF_CONDUCT.md)
+[![GitHub Followers](https://img.shields.io/github/followers/uw-ssec?style=flat-square&logo=github&label=Org%20Followers&color=4B2E83)](https://github.com/uw-ssec)
+[![Public Repos](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Forgs%2Fuw-ssec&query=%24.public_repos&label=Public%20Repos&style=flat-square&logo=github&color=85754D)](https://github.com/orgs/uw-ssec/repositories)
 
+The Scientific Software Engineering Center is part of the [University of Washington eScience Institute](https://escience.washington.edu/). We pair professional software engineers with researchers across disciplines to embed software engineering best practices into scientific work, and to ship open-source tools that continue to serve the community long after our engagements end.
 
+Founded in January 2022 through a [Schmidt Sciences](https://www.schmidtsciences.org/) initiative, SSEC is one of a small number of centers nationally dedicated to growing scientific software engineering as a discipline.
+
+- Home: <https://escience.washington.edu/software-engineering/ssec/>
+- About the Center: <https://escience.washington.edu/software-engineering/ssec/about-2/>
+- Project portfolio: <https://escience.washington.edu/software-engineering/ssec/ssec-project-archives/>
+
+---
+
+## What We Do
+
+- **Collaborate with research teams** to design, build, and harden software that powers scientific inquiry.
+- **Lay durable open-source foundations** so principal investigators, students, and communities can carry projects forward.
+- **Scale research software engineering (RSE) culture** through training, tutorials, and mentorship of graduate research scholars.
+- **Explore AI for science** through our AI Hub initiative — applying generative AI to accelerate research and developer productivity.
+
+We work across domains including astronomy, oceanography, seismology, genetics, ecology, biodiversity, bioethics, medicine, energy, education, and disaster response.
+
+---
+
+## Featured Projects
+
+A curated slice of our active and recently archived work. See the [full portfolio](https://escience.washington.edu/software-engineering/ssec/ssec-project-archives/) for everything else.
+
+| Project | Domain | What it does |
+| --- | --- | --- |
+| [antenna](https://github.com/uw-ssec/antenna) | Ecology / Education | AI-powered insect camera-trap toolset for conservation research |
+| [bioethics](https://github.com/uw-ssec/bioethics) | Bioethics / Medicine | Generates plain-language lay summaries of academic research for study participants |
+| [biodiversity-horizons](https://github.com/uw-ssec/biodiversity-horizons) | Ecology | Predicts biodiversity risks under climate change scenarios |
+| [HPyX](https://github.com/uw-ssec/HPyX) | HPC / Software Engineering | Brings high-performance parallelism to Python |
+| [ovro-lwa-portal](https://github.com/uw-ssec/ovro-lwa-portal) | Astronomy | Accessible data platform for the Owens Valley Long Wavelength Array |
+| [protein-design-pipelines](https://github.com/uw-ssec/protein-design-pipelines) | Genetics / Bioethics | Reproducible pipelines aligning model developers and protein designers |
+| [idd-database](https://github.com/uw-ssec/idd-database) | Medicine | Centralized data portal for intellectual and developmental disability research |
+| [caustics](https://github.com/uw-ssec/caustics) | Astronomy | Gravitational lensing simulator for the ML era |
+| [phylo2vec](https://github.com/uw-ssec/phylo2vec) | Genetics | Vector representation for binary phylogenetic trees |
+| [SafeMind](https://github.com/uw-ssec/SafeMind) | Mental Health / AI Safety | Safer GenAI for mental health via lived-experience–grounded simulation |
+| [llmaven](https://github.com/uw-ssec/llmaven) | AI / NAIRR | NAIRR-backed AI gateway exploring LLM infrastructure for researchers |
+| [rse-plugins](https://github.com/uw-ssec/rse-plugins) | Developer Tooling | Research software engineering plugins for coding agents |
+
+---
+
+## Learn With Us
+
+- [tutorials](https://github.com/uw-ssec/tutorials) — SSEC tutorials on scientific computing, cloud, and AI topics
+- [rse-guidelines](https://github.com/uw-ssec/rse-guidelines) — Research software engineering guidelines we follow and evolve
+- [learning-open-source](https://github.com/uw-ssec/learning-open-source) — A gentle starting point for new open-source contributors
+- [codeuw](https://github.com/uw-ssec/codeuw) — Curated tasks for contributing to scientific software projects
+
+---
+
+## Contributing
+
+All of our work is open by default. Before opening a PR, please read:
+
+- [CONTRIBUTING.md](https://github.com/uw-ssec/.github/blob/main/CONTRIBUTING.md) — how we collaborate, branch, review, and ship
+- [CODE_OF_CONDUCT.md](https://github.com/uw-ssec/.github/blob/main/CODE_OF_CONDUCT.md) — the community standards we hold ourselves to
+
+New contributors are welcome. Issues labeled `good first issue` on individual repositories are a great place to start.
+
+---
+
+## Get Involved
+
+- **Researchers** interested in partnering with SSEC: see [Get involved with SSEC](https://escience.washington.edu/get-involved-with-ssec/).
+- **Students** interested in our Graduate Research Scholar program: reach out through the eScience Institute.
+- **Community** questions and discussions: use the Discussions tab on any of our repositories.
+
+---
+
+## Acknowledgments
+
+SSEC is supported by [Schmidt Sciences](https://www.schmidtsciences.org/) and hosted within the [UW eScience Institute](https://escience.washington.edu/). We partner with research groups across UW and with collaborators internationally.
+
+---
+
+<sub>The resulting tools are open source and reusable, designed to sustain discovery beyond SSEC's involvement in the projects.</sub>


### PR DESCRIPTION
## Summary

Replaces the 4-line stub in `profile/README.md` with a structured org profile README that accurately reflects who SSEC is and what we do, following best practices from curated org-README collections.

### What's new

- **Tagline + mission** tied to the [UW eScience Institute](https://escience.washington.edu/) and the Schmidt Sciences–backed launch (Jan 2022).
- **Badge row** using UW husky purple (`#4B2E83`), metallic gold (`#85754D`), and Schmidt Sciences teal (`#53B2B5`). Two badges (Org Followers, Public Repos) auto-update from the GitHub API.
- **Featured Projects table** — 12 curated repos across ecology, astronomy, genetics, medicine, HPC, and AI, each linked to its live repo on the org.
- **Learn With Us** — tutorials, RSE guidelines, open-source onboarding.
- **Contributing + Get Involved + Acknowledgments** sections with links to `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and the full [project archive](https://escience.washington.edu/software-engineering/ssec/ssec-project-archives/).

Content was sourced directly from:
- https://escience.washington.edu/software-engineering/ssec/
- https://escience.washington.edu/software-engineering/ssec/about-2/
- https://escience.washington.edu/software-engineering/ssec/ssec-project-archives/

## Test plan

- [ ] Preview rendered `profile/README.md` on GitHub after merge — confirm it shows on https://github.com/uw-ssec
- [ ] Verify all project links in the Featured Projects table resolve (no 404s)
- [ ] Verify badges render correctly (shields.io availability)
- [ ] Confirm the two dynamic badges (Org Followers, Public Repos) display live counts
- [ ] Sanity-check links to `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` resolve to this repo's `main`